### PR TITLE
Add tzdata package to Alpine image

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -5,7 +5,7 @@ FROM alpine:latest
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk add --no-cache bash shadow@community openssh-server-pam openssh-sftp-server && \
+    apk add --no-cache bash shadow@community openssh-server-pam openssh-sftp-server tzdata && \
     ln -s /usr/sbin/sshd.pam /usr/sbin/sshd && \
     mkdir -p /var/run/sshd && \
     rm -f /etc/ssh/ssh_host_*key*


### PR DESCRIPTION
Add `tzdata` package to Alpine image to be able to set the timezone inside the container. This makes the behaviour identical to Debian image, where you are able to use the `TZ` environment variable to set the desired timezone, while still keeping the small image size advantage Alpine offers (the size increase is only 1.1 MB). 