### PR TITLE
Fix SCP support, but break jail

### DIFF
--- a/files/permit-scp.sh
+++ b/files/permit-scp.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
-# Permit scp
 case $SSH_ORIGINAL_COMMAND in
- 'scp'*)
+# Permit scp when run in internal source/dest/dir mode
+# NOTE: adding path does not protect from rogue symlinks
+ "scp -f $HOME/"*)
     $SSH_ORIGINAL_COMMAND
     ;;
+ "scp -t $HOME/"*)
+    $SSH_ORIGINAL_COMMAND
+    ;;
+ "scp -d $HOME"*)
+    $SSH_ORIGINAL_COMMAND
+    ;;
+# Permit standard sftp - by pats, as `internal-sftp` works only in sshd_config
+ "/usr/lib/openssh/sftp-server")
+    $SSH_ORIGINAL_COMMAND
+    ;;
+# Drop anything else
  *)
     echo "Access Denied"
     ;;

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -13,12 +13,7 @@ PermitRootLogin no
 X11Forwarding no
 AllowTcpForwarding no
 
-# Force sftp and chroot jail
-Subsystem sftp internal-sftp
-ForceCommand internal-sftp
-ChrootDirectory %h
-
-# Permit SCP
+Subsystem sftp /usr/lib/openssh/sftp-server
 ForceCommand /usr/local/bin/permit-scp.sh
 
 # Enable this for more logs


### PR DESCRIPTION
Fix SCP support, but break jail. Proposing this change anyway as I really needed support for SCP from an embedded system (some modern systems somehow issue SFTP even when `scp` client is called).

---

Unfortunately, OpenSSH allows jailing with SFTP by using a dirty hack - `internal-sftp` is a magic way to call internal SFTP process, allowing user to break [the rules of `ChrootDirectory`](https://man.openbsd.org/sshd_config#ChrootDirectory), which require a set of files to be under path specified (things like binary specified in `ForceCommand` *and basic /dev nodes*).

At the same time, `internal-sftp` binary (`/usr/lib/openssh/sftp-server`) completely delegates jailing/chrooting to OpenSSH and has no command-line options to restrict what it can read/write.

On the other hand, `scp` can be somewhat jailed on its own (except symlinks, which should be doable by other tools on Linux) due to a fixed way it sends and receives files with [`-f`, `-t` and `-d`](https://web.archive.org/web/20170215184048/https://blogs.oracle.com/janp/entry/how_the_scp_protocol_works).

---

Maybe some alternative SSH server should also be considered - I was originally hoping for the ability to `Match` selected subsystem and based on that set standard SFTP config or just leave `ForceCommand` with proxy script for SCP.